### PR TITLE
Use PHP 5.6 splat operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $default = function (RequestInterface $request) {
     return new Response();
 };
 
-$stack = new Stack($middleware, $default);
+$stack = new Stack($default, ...$middleware);
 
 // Any implementation of PSR-7 ServerRequestInterface
 $request = ServerRequest::fromGlobals();

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -9,15 +9,22 @@ use Psr\Http\Message\ServerRequestInterface;
 class Stack
 {
     /**
+     * @var callable
+     */
+    private $default;
+
+    /**
      * @var array
      */
     private $middleware = [];
 
     /**
+     * @param callable $default to call when no middleware is available
      * @param array $middleware
      */
-    public function __construct(array $middleware = [])
+    public function __construct(callable $default, ...$middleware)
     {
+        $this->default = $default;
         array_map([$this, 'append'], $middleware);
     }
 
@@ -49,13 +56,12 @@ class Stack
      * Dispatch the middleware stack.
      *
      * @param ServerRequestInterface $request
-     * @param callable $default to call when no middleware is available
      *
      * @return ResponseInterface
      */
-    public function dispatch(ServerRequestInterface $request, callable $default)
+    public function dispatch(ServerRequestInterface $request)
     {
-        $delegate = new Delegate($this->middleware, $default);
+        $delegate = new Delegate($this->middleware, $this->default);
 
         return $delegate->process($request);
     }

--- a/tests/StackTest.php
+++ b/tests/StackTest.php
@@ -18,8 +18,8 @@ class StackTest extends TestCase
         $default = $this->defaultReturnsResponse($response);
 
         // Run
-        $stack = new Stack();
-        $output = $stack->dispatch($request, $default);
+        $stack = new Stack($default);
+        $output = $stack->dispatch($request);
 
         // Verify
         $this->assertSame($response, $output);
@@ -51,7 +51,7 @@ class StackTest extends TestCase
         }, $mocks);
 
         // Run
-        $stack = new Stack($middleware, $default);
+        $stack = new Stack($default, ...$middleware);
         $output = $stack->dispatch($request, $default);
 
         // Verify
@@ -73,7 +73,7 @@ class StackTest extends TestCase
         $three = Phony::mock(ServerMiddlewareInterface::class)->get();
 
         // Run
-        $stack = new Stack([$one], $default);
+        $stack = new Stack($default, $one);
         $accessible_stack = Liberator::liberate($stack);
 
         // Verify


### PR DESCRIPTION
Conflicts #1 and #2, but I would prefer this one.
Please note: this a predecessor of #5, which subsumes it.

It think it is the most consistent one:
```php
$stack = new Stack($default);
$stack->append($one);
$stack->append($two);

// same result as
$stack = new Stack($default, $one);
$stack->append($two);

// same result as
$stack = new Stack($default, $one, $two);
```

Same with arrays:

```php
// same result as
$middlewares = [];
$middlewares[] = $one;
$middlewares[] = $two;
$stack = new Stack($default, ...$middlewares);

// obviously the same result as
$middlewares = [];
array_push($middlewares, $one);
array_push($middlewares, $two);
$stack = new Stack($default, ...$middlewares);

// same result as
$middlewares = [
   $one,
   $two,
];
$stack = new Stack($default, ...$middlewares);
```

At the very end, another variant for complicated middleware names, showing that `$default` should be the very first parameter:
```php
$stack = new Stack($default, ...[
   new \Some\Very\Long\Namespace\For\A\Middleware\One($with, $many, $parameters),
   new \Some\Very\Long\Namespace\For\A\Middleware\Two($with, $many, $parameters),
]);
```