### PR TITLE
Stacks are middlewares too

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $default = function (RequestInterface $request) {
     return new Response();
 };
 
-$stack = new Stack(...$middleware);
+$stack = new Stack($middleware);
 
 // Any implementation of PSR-7 ServerRequestInterface
 $request = ServerRequest::fromGlobals();

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $default = function (RequestInterface $request) {
     return new Response();
 };
 
-$stack = new Stack($middleware, $default);
+$stack = new Stack($default, ...$middleware);
 
 // Any implementation of PSR-7 ServerRequestInterface
 $request = ServerRequest::fromGlobals();

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ $default = function (RequestInterface $request) {
     return new Response();
 };
 
-$stack = new Stack($default, ...$middleware);
+$stack = new Stack(...$middleware);
 
 // Any implementation of PSR-7 ServerRequestInterface
 $request = ServerRequest::fromGlobals();
-$response = $stack->dispatch($request);
+$response = $stack->dispatch($request, $default);
 ```

--- a/src/DelegateToCallableAdapter.php
+++ b/src/DelegateToCallableAdapter.php
@@ -1,0 +1,34 @@
+<?php
+namespace Equip\Dispatch;
+
+use Interop\Http\Middleware\DelegateInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class DelegateToCallableAdapter
+{
+    /**
+     * @var DelegateInterface
+     */
+    private $adaptee;
+
+    /**
+     * @param DelegateInterface $adaptee
+     */
+    public function __construct(DelegateInterface $adaptee)
+    {
+        $this->adaptee = $adaptee;
+    }
+
+    /**
+     * Process the request using a delegate.
+     *
+     * @param RequestInterface $request
+     *
+     * @return ResponseInterface
+     */
+    public function __invoke(RequestInterface $request)
+    {
+        return $this->adaptee->process($request);
+    }
+}

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -9,15 +9,22 @@ use Psr\Http\Message\ServerRequestInterface;
 class Stack
 {
     /**
+     * @var callable
+     */
+    private $default;
+
+    /**
      * @var array
      */
     private $middleware = [];
 
     /**
+     * @param callable $default to call when no middleware is available
      * @param array $middleware
      */
-    public function __construct(array $middleware = [])
+    public function __construct(callable $default, ...$middleware)
     {
+        $this->default = $default;
         array_map([$this, 'append'], $middleware);
     }
 
@@ -49,13 +56,12 @@ class Stack
      * Dispatch the middleware stack.
      *
      * @param ServerRequestInterface $request
-     * @param callable $default to call when no middleware is available
      *
      * @return ResponseInterface
      */
-    public function dispatch(ServerRequestInterface $request, callable $default)
+    public function dispatch(ServerRequestInterface $request)
     {
-        $delegate = new Delegate($this->middleware, $default);
+        $delegate = new Delegate($this->middleware, $this->default);
 
         return $delegate->process($request);
     }

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -51,13 +51,13 @@ class Stack implements ServerMiddlewareInterface
      * to the next middleware component to create the response.
      *
      * @param ServerRequestInterface $request
-     * @param DelegateInterface $nextContanierDelegate
+     * @param DelegateInterface $nextContainerDelegate
      *
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $nextContanierDelegate)
+    public function process(ServerRequestInterface $request, DelegateInterface $nextContainerDelegate)
     {
-        $delegate = new Delegate($this->middleware, new DelegateToCallableAdapter($nextContanierDelegate));
+        $delegate = new Delegate($this->middleware, new DelegateToCallableAdapter($nextContainerDelegate));
 
         return $delegate->process($request);
     }

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -17,7 +17,7 @@ class Stack implements ServerMiddlewareInterface
     /**
      * @param array $middleware
      */
-    public function __construct(...$middleware)
+    public function __construct(array $middleware = [])
     {
         array_map([$this, 'append'], $middleware);
     }

--- a/tests/StackTest.php
+++ b/tests/StackTest.php
@@ -18,8 +18,8 @@ class StackTest extends TestCase
         $default = $this->defaultReturnsResponse($response);
 
         // Run
-        $stack = new Stack();
-        $output = $stack->dispatch($request, $default);
+        $stack = new Stack($default);
+        $output = $stack->dispatch($request);
 
         // Verify
         $this->assertSame($response, $output);
@@ -51,7 +51,7 @@ class StackTest extends TestCase
         }, $mocks);
 
         // Run
-        $stack = new Stack($middleware, $default);
+        $stack = new Stack($default, ...$middleware);
         $output = $stack->dispatch($request, $default);
 
         // Verify
@@ -73,7 +73,7 @@ class StackTest extends TestCase
         $three = Phony::mock(ServerMiddlewareInterface::class)->get();
 
         // Run
-        $stack = new Stack([$one], $default);
+        $stack = new Stack($default, $one);
         $accessible_stack = Liberator::liberate($stack);
 
         // Verify

--- a/tests/StackTest.php
+++ b/tests/StackTest.php
@@ -51,7 +51,7 @@ class StackTest extends TestCase
         }, $mocks);
 
         // Run
-        $stack = new Stack(...$middleware);
+        $stack = new Stack($middleware);
         $output = $stack->dispatch($request, $default);
 
         // Verify
@@ -73,7 +73,7 @@ class StackTest extends TestCase
         $three = Phony::mock(ServerMiddlewareInterface::class)->get();
 
         // Run
-        $stack = new Stack($one);
+        $stack = new Stack([$one]);
         $accessible_stack = Liberator::liberate($stack);
 
         // Verify
@@ -121,10 +121,10 @@ class StackTest extends TestCase
             return $middleware->get();
         }, $mocks);
 
-        $stack = new Stack(...[
+        $stack = new Stack([
             $middleware[0],
             $middleware[1],
-            new Stack(...[
+            new Stack([
                 $middleware[2],
                 $middleware[3],
             ]),


### PR DESCRIPTION
This is a consistent continuation of #2 and allows reusing `Stack` as `ServerMiddlewareInterface` in other Middleware containers:

```php
// I've used the splat operator:
$stack = new Stack($middlewareOne, $middlewareTwo);

$middlewares = [
   // …
   new AwesomePsrMiddleware(),
   // …
   $stack,
   // …
];

// some foreign stack container:
$foreign = new MiddlewareContainer($middlewares, …);
$foreign->dispatch($request);
```

**See #6 for deatils.**
