### PR TITLE
Support latest PSR-15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
   - nightly
-  - hhvm
 
 matrix:
   fast_finish: true
   allow_failures:
     - php: nightly
   include:
-    - php: 5.6
+    - php: 7.0
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "http-interop/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6.0",
+        "phpunit/phpunit": "^5.7",
         "eloquent/phony": "^0.14.3",
         "eloquent/liberator": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "http-interop/http-middleware": "^0.5"
+        "http-interop/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0",
         "http-interop/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^5.7|^6.0",
         "eloquent/phony": "^0.14.3",
         "eloquent/liberator": "^2.0"
     },

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -33,13 +33,6 @@ class Handler implements RequestHandlerInterface
         $this->default = $default;
     }
 
-    /**
-     * Process the request using the current middleware.
-     *
-     * @param ServerRequestInterface $request
-     *
-     * @return ResponseInterface
-     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         if (empty($this->middleware[$this->index])) {

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -40,7 +40,7 @@ class Handler implements RequestHandlerInterface
      *
      * @return ResponseInterface
      */
-    public function handle(ServerRequestInterface $request)
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
         if (empty($this->middleware[$this->index])) {
             return call_user_func($this->default, $request);

--- a/src/MiddlewareCollection.php
+++ b/src/MiddlewareCollection.php
@@ -73,9 +73,6 @@ class MiddlewareCollection implements MiddlewareInterface
         return $handler->handle($request);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $nextContainerHandler): ResponseInterface
     {
         $default = new HandlerProxy($nextContainerHandler);

--- a/src/MiddlewareCollection.php
+++ b/src/MiddlewareCollection.php
@@ -76,7 +76,7 @@ class MiddlewareCollection implements MiddlewareInterface
     /**
      * @inheritdoc
      */
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $nextContainerHandler)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $nextContainerHandler): ResponseInterface
     {
         $default = new HandlerProxy($nextContainerHandler);
         $handler = new Handler($this->middleware, $default);


### PR DESCRIPTION
This PR adds support for `http-interop/http-server-middleware: ^1.0`.  Also removes Travis tests for PHP 5.6 and HHVM which are not supported by the PSR anymore.